### PR TITLE
Add a test for validateByteRange with bytes > 127

### DIFF
--- a/operators/validateByteRange.json
+++ b/operators/validateByteRange.json
@@ -47,5 +47,12 @@
       "name" : "validateByteRange",
       "ret" : 1,
       "type" : "op"
+   },
+   {
+      "input" : "\u00d0\u0090",
+      "param" : "0-255",
+      "name" : "validateByteRange",
+      "ret" : 0,
+      "type" : "op"
    }
 ]


### PR DESCRIPTION
Bytes with codes > 127 make a separate special case because they can be handled differently depending on whether signed or unsigned char is used to hold them during processing. See https://github.com/SpiderLabs/ModSecurity/pull/1523