### PR TITLE
Extend RX operator test cases with re_groups

### DIFF
--- a/operators/rx.json
+++ b/operators/rx.json
@@ -39,14 +39,16 @@
       "input" : "abcdefghi",
       "type" : "op",
       "ret" : 1,
-      "name" : "rx"
+      "name" : "rx",
+      "re_groups": ["def"]
    },
    {
       "param" : "ghi",
       "input" : "abcdefghi",
       "name" : "rx",
       "type" : "op",
-      "ret" : 1
+      "ret" : 1,
+      "re_groups": ["ghi"]
    },
    {
       "ret" : 0,
@@ -61,5 +63,92 @@
       "name" : "rx",
       "param" : "(?i:(sleep\\((\\s*?)(\\d*?)(\\s*?)\\)|benchmark\\((.*?)\\,(.*?)\\)))",
       "input" : "SELECT pg_sleep(10);"
+   },
+   {
+      "type" : "op",
+      "name" : "rx",
+      "param" : "(abc)(def)",
+      "input" : "abcdef",
+      "ret" : 1,
+      "re_groups": ["abcdef", "abc", "def"]
+   },
+   {
+      "type" : "op",
+      "name" : "rx",
+      "param" : "(a|b|1|2)(a|b|1|2)",
+      "input" : "a2b1",
+      "ret" : 1,
+      "re_groups": ["a2", "a", "2"]
+   },
+   {
+      "type" : "op",
+      "name" : "rx",
+      "param" : "<\\?(?!xml)",
+      "input" : "<?php",
+      "ret" : 1,
+      "re_groups": ["<?"]
+   },
+   {
+      "type" : "op",
+      "name" : "rx",
+      "param" : "<\\?(?!xml)",
+      "input" : "<?xml",
+      "ret" : 0
+   },
+   {
+      "type" : "op",
+      "name" : "rx",
+      "param" : "abc\ndef",
+      "input" : "abc\ndef",
+      "ret" : 1,
+      "re_groups": ["abc\ndef"]
+   },
+   {
+      "type" : "op",
+      "name" : "rx",
+      "param" : "[a-z]\n",
+      "input" : "a\nb\nc\n",
+      "ret" : 1,
+      "re_groups": ["a\n"]
+   },
+   {
+      "type" : "op",
+      "name" : "rx",
+      "param" : "[a-z]*",
+      "input" : "abkjgdsgk",
+      "ret" : 1,
+      "re_groups": ["abkjgdsgk"]
+   },
+   {
+      "type" : "op",
+      "name" : "rx",
+      "param" : "([a-z]*)",
+      "input" : "",
+      "ret" : 1,
+      "re_groups": ["", ""]
+   },
+   {
+      "type" : "op",
+      "name" : "rx",
+      "param" : "[a-z]*",
+      "input" : "aaa0bbb",
+      "ret" : 1,
+      "re_groups": ["aaa"]
+   },
+   {
+      "type" : "op",
+      "name" : "rx",
+      "param" : "[a-z]*",
+      "input" : "aaa00bbb",
+      "ret" : 1,
+      "re_groups": ["aaa"]
+   },
+   {
+      "type" : "op",
+      "name" : "rx",
+      "param" : "(a)(b?)(c)",
+      "input" : "ac",
+      "ret" : 1,
+      "re_groups": ["ac", "a", "", "c"]
    }
 ]


### PR DESCRIPTION
See SpiderLabs/ModSecurity#2007.

Adds `"re_groups"` field to RX (regular expression) test cases, allowing not only binary match-no match test, but also verifying that capturing groups are correct.

This obviously needs support from the test case runner, but the change is backward-compatible in the way that these new fields can be ignored.